### PR TITLE
Add Better support for generating charts in existing Band BoomBox songs folder

### DIFF
--- a/MediumHardMod/.editorconfig
+++ b/MediumHardMod/.editorconfig
@@ -153,3 +153,7 @@ dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_readonly_field = true:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion

--- a/MediumHardMod/.editorconfig
+++ b/MediumHardMod/.editorconfig
@@ -1,0 +1,155 @@
+
+[*.cs]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.private_field_or_property_should_be_prefix_camel_case.severity = suggestion
+dotnet_naming_rule.private_field_or_property_should_be_prefix_camel_case.symbols = private_field_or_property
+dotnet_naming_rule.private_field_or_property_should_be_prefix_camel_case.style = prefix_camel_case
+
+dotnet_naming_rule.constants_should_be_all_uppercase.severity = suggestion
+dotnet_naming_rule.constants_should_be_all_uppercase.symbols = constants
+dotnet_naming_rule.constants_should_be_all_uppercase.style = all_uppercase
+
+# Symbol specifications
+
+dotnet_naming_symbols.private_field_or_property.applicable_kinds = property, field
+dotnet_naming_symbols.private_field_or_property.applicable_accessibilities = private
+dotnet_naming_symbols.private_field_or_property.required_modifiers = 
+
+dotnet_naming_symbols.constants.applicable_kinds = property, field, local, struct, enum
+dotnet_naming_symbols.constants.applicable_accessibilities = *
+dotnet_naming_symbols.constants.required_modifiers = const
+
+# Naming styles
+
+dotnet_naming_style.prefix_camel_case.required_prefix = _
+dotnet_naming_style.prefix_camel_case.required_suffix = 
+dotnet_naming_style.prefix_camel_case.word_separator = 
+dotnet_naming_style.prefix_camel_case.capitalization = camel_case
+
+dotnet_naming_style.all_uppercase.required_prefix = 
+dotnet_naming_style.all_uppercase.required_suffix = 
+dotnet_naming_style.all_uppercase.word_separator = _
+dotnet_naming_style.all_uppercase.capitalization = all_upper
+csharp_indent_labels = one_less_than_current
+csharp_space_around_binary_operators = before_and_after
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = false:warning
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+
+[*.vb]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.severity = warning
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.style = underscore_camel_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = friend, private, private_protected
+dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.required_suffix = 
+dotnet_naming_style.underscore_camel_case.word_separator = 
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion

--- a/MediumHardMod/Difficulty.cs
+++ b/MediumHardMod/Difficulty.cs
@@ -1,0 +1,11 @@
+﻿namespace MediumHardMod;
+
+public enum Difficulty
+{
+    Beginner = 0,
+    Medium = 1,
+    Hard = 2,
+    Expert = 3,
+    Master = 4,
+    Extra = 10
+}

--- a/MediumHardMod/Difficulty.cs
+++ b/MediumHardMod/Difficulty.cs
@@ -2,14 +2,6 @@
 
 public enum Difficulty
 {
-    Beginner,
-    Medium,
-    Hard,
-    Expert,
-    Master,
-    Extra = 10
-}
-{
     Beginner = 0,
     Medium = 1,
     Hard = 2,

--- a/MediumHardMod/Difficulty.cs
+++ b/MediumHardMod/Difficulty.cs
@@ -2,6 +2,14 @@
 
 public enum Difficulty
 {
+    Beginner,
+    Medium,
+    Hard,
+    Expert,
+    Master,
+    Extra = 10
+}
+{
     Beginner = 0,
     Medium = 1,
     Hard = 2,

--- a/MediumHardMod/MediumHardMod.csproj
+++ b/MediumHardMod/MediumHardMod.csproj
@@ -10,7 +10,7 @@
     <PublishAot>true</PublishAot>
   </PropertyGroup>
   <ItemGroup>
-    <EditorConfigFiles Remove="C:\Projects\BoomBoxExtraMod\BandBoomBoxExtraMod\MediumHardMod\.editorconfig" />
+    <EditorConfigFiles Remove=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
     <None Include="C:\Projects\BoomBoxExtraMod\BandBoomBoxExtraMod\MediumHardMod\.editorconfig" />

--- a/MediumHardMod/MediumHardMod.csproj
+++ b/MediumHardMod/MediumHardMod.csproj
@@ -9,4 +9,10 @@
   <PropertyGroup>
     <PublishAot>true</PublishAot>
   </PropertyGroup>
+  <ItemGroup>
+    <EditorConfigFiles Remove="C:\Projects\BoomBoxExtraMod\BandBoomBoxExtraMod\MediumHardMod\.editorconfig" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="C:\Projects\BoomBoxExtraMod\BandBoomBoxExtraMod\MediumHardMod\.editorconfig" />
+  </ItemGroup>
 </Project>

--- a/MediumHardMod/MediumHardMod.csproj
+++ b/MediumHardMod/MediumHardMod.csproj
@@ -13,6 +13,6 @@
     <EditorConfigFiles Remove=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="C:\Projects\BoomBoxExtraMod\BandBoomBoxExtraMod\MediumHardMod\.editorconfig" />
+    <None Include=".editorconfig" />
   </ItemGroup>
 </Project>

--- a/MediumHardMod/Program.cs
+++ b/MediumHardMod/Program.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 
 public static class Program
 {
+    public static bool OverwriteExistingCharts { get; set; } = false;
     public static void Main(string[] args)
     {
         if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]) || !Directory.Exists(args[0]))
@@ -16,7 +17,18 @@ public static class Program
             return;
         }
 
-        foreach (var inputFile in new DirectoryInfo(args[0]).GetFiles("*.sjson"))
+        if (args.Contains("-Overwrite"))
+            OverwriteExistingCharts = true;
+
+        ProcessFolder(args[0]);
+    }
+
+    public static void ProcessFolder(string folder)
+    {
+        foreach (var subFolder in Directory.GetDirectories(folder))
+            ProcessFolder(subFolder);
+
+        foreach (var inputFile in new DirectoryInfo(folder).GetFiles("*.sjson"))
         {
             var (success, message) = ProcessFile(inputFile);
             Output.WriteLine(!success, message);
@@ -31,10 +43,10 @@ public static class Program
         if (song is null)
             return (false, $"{inputFile} is not a valid song file");
 
-        if (song?.SongCharts is null || song?.SongCharts.Count == 0)
+        if (song.SongCharts.Count == 0)
             return (false, $"{inputFile} does not contain any charts");
 
-        var mediumChart = song?.SongCharts?.FirstOrDefault(x => x.Difficulty == 1);
+        var mediumChart = song.SongCharts.FirstOrDefault(x => x.Difficulty == (int) Difficulty.Medium);
 
         if (mediumChart is null)
             return (false, $"No medium song chart found in file \"{inputFile.Name}\"");
@@ -42,11 +54,14 @@ public static class Program
         if (mediumChart.Notes is null || mediumChart.Notes.Length == 0)
             return (false, $"No medium notes found in file \"{inputFile.Name}\"");
 
-        ReplaceNotes.AddMedHardDifficulty(song!, mediumChart);
+        if (song.HasChart( Difficulty.Extra) && !OverwriteExistingCharts)
+            return (false, $"Extra chart already exists in file \"{inputFile.Name}\"");
+
+        ReplaceNotes.AddExtraDifficulty(song, mediumChart);
 
         var result = JsonSerializer.Serialize(song, typeof(Song), SongJsonContext.Default);
-        var outputFile = $"{Path.GetFileNameWithoutExtension(inputFile.Name)}-medHard.sjson";
-        File.WriteAllText(Path.Combine(inputFile.DirectoryName!, "Output", outputFile), result);
-        return (true, $"{outputFile} created");
+        File.WriteAllText(inputFile.FullName, result);
+
+        return (true, $"Extra chart successfully created in \"{inputFile}\"");
     }
 }

--- a/MediumHardMod/ReplaceNotes.cs
+++ b/MediumHardMod/ReplaceNotes.cs
@@ -38,7 +38,8 @@ internal static class ReplaceNotes
 
     public static void AddExtraDifficulty(Song song, SongChart mediumChart)
     {
-        if (song == null) throw new ArgumentNullException(nameof(song));
+        if (song is null) throw new ArgumentNullException(nameof(song));
+        if (mediumChart is null) throw new ArgumentNullException(nameof(mediumChart));
         if (mediumChart == null) throw new ArgumentNullException(nameof(mediumChart));
 
         SongChart extraChart = new()

--- a/MediumHardMod/ReplaceNotes.cs
+++ b/MediumHardMod/ReplaceNotes.cs
@@ -36,27 +36,35 @@ internal static class ReplaceNotes
         return result.ToString();
     }
 
-    public static void AddMedHardDifficulty(Song song, SongChart mediumChart)
+    public static void AddExtraDifficulty(Song song, SongChart mediumChart)
     {
-        if (song?.SongCharts is null) return;
+        if (song == null) throw new ArgumentNullException(nameof(song));
+        if (mediumChart == null) throw new ArgumentNullException(nameof(mediumChart));
 
-        SongChart medHardChart = new()
+        SongChart extraChart = new()
         {
-            Difficulty = 10,
+            Difficulty = (int) Difficulty.Extra,
             Notes = new string[mediumChart.Notes?.Length ?? 0],
             DifficultyLevel = mediumChart.DifficultyLevel + 1,
             Group = mediumChart.Group
         };
 
-        bool replace = true;
-
-        for (int i = 0; i < mediumChart?.Notes?.Length; i++)
+        // Remove any existing extra charts
+        var existingCharts = song.SongCharts.Where(x => x.Difficulty == 10 && x.Group == extraChart.Group).ToList();
+        foreach (var chart in existingCharts)
         {
-            var newNote = ReplaceAllNotes(mediumChart.Notes[i], ref replace);
-            medHardChart.Notes[i] = newNote;
+            song.SongCharts.Remove(chart);
         }
 
-        song.SongCharts.Add(medHardChart);
-        song.SongCharts = song?.SongCharts?.OrderBy(x => x.DifficultyLevel).ToList();
+        bool replace = true;
+
+        for (int i = 0; i < mediumChart.Notes?.Length; i++)
+        {
+            var newNote = ReplaceAllNotes(mediumChart.Notes[i], ref replace);
+            extraChart.Notes[i] = newNote;
+        }
+
+        song.SongCharts.Add(extraChart);
+        song.SongCharts = song.SongCharts.OrderBy(x => x.DifficultyLevel).ToList();
     }
 }

--- a/MediumHardMod/Song.cs
+++ b/MediumHardMod/Song.cs
@@ -15,6 +15,11 @@ internal class Song
     public decimal Offset { get; set; }
     public decimal Length { get; set; }
     public int BeatsPerMeasure { get; set; }
-    public Dictionary<int, string>? Sections { get; set; }
-    public List<SongChart>? SongCharts { get; set; }
+    public Dictionary<int, string> Sections { get; set; } = new();
+    public List<SongChart> SongCharts { get; set; } = new();
+
+    public bool HasChart(Difficulty difficulty)
+    {
+        return this.SongCharts.Any(e => e.Difficulty == (int) difficulty);
+    }
 }

--- a/MediumHardMod/Song.cs
+++ b/MediumHardMod/Song.cs
@@ -15,7 +15,7 @@ internal class Song
     public decimal Offset { get; set; }
     public decimal Length { get; set; }
     public int BeatsPerMeasure { get; set; }
-    public Dictionary<int, string> Sections { get; set; } = new();
+    public Dictionary<double, string> Sections { get; set; } = new();
     public List<SongChart> SongCharts { get; set; } = new();
 
     public bool HasChart(Difficulty difficulty)

--- a/MediumHardMod/Song.cs
+++ b/MediumHardMod/Song.cs
@@ -20,6 +20,6 @@ internal class Song
 
     public bool HasChart(Difficulty difficulty)
     {
-        return this.SongCharts.Any(e => e.Difficulty == (int) difficulty);
+        return SongCharts.Any(e => e.Difficulty == (int) difficulty);
     }
 }

--- a/MediumHardMod/SongChart.cs
+++ b/MediumHardMod/SongChart.cs
@@ -5,5 +5,5 @@ internal class SongChart
     public string? Group { get; set; }
     public int Difficulty { get; set; }
     public int DifficultyLevel { get; set; }
-    public string[]? Notes { get; set; }
+    public string[] Notes { get; set; } = Array.Empty<string>();
 }


### PR DESCRIPTION
Added support for subfolders. All SJSON files in the specified folder, as well as any subfolders, will now be processed.
Generated charts are now saved to the same SJSON file as the medium chart they are generated from. 
Added -Overwrite argument to allow overwriting existing Extra charts 
Introduced Difficulty as Enum
Removed some unneeded null checks (and initialized collections by default) 
Added .editorconfig file